### PR TITLE
Creates foods#destroy functionality

### DIFF
--- a/controllers/api/v1/foods_controller.js
+++ b/controllers/api/v1/foods_controller.js
@@ -17,20 +17,21 @@ async function index(req, res) {
   }
 }
 
-async function show(req, res) {
+function show(req, res) {
   let foodId = req.params.id
-  let singleFood = await Food.findOne({ where: { id: foodId } });
 
-    if(singleFood) {
-      res.setHeader("Content-Type", "application/json");
-      res.status(200).send(FoodSerializer.format(singleFood));
-    } else {
-      res.setHeader("Content-Type", "application/json");
-      res.status(404).send({"error": "Food not found"});
-    }
+  Food.findOne({ where: { id: foodId } })
+  .then(singleFood => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).send(FoodSerializer.format(singleFood));
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(404).send({"error": error.message});
+  })
 }
 
-async function create(req, res) {
+function create(req, res) {
   let newFood = req.body.food.name;
   let calories = req.body.food.calories;
 
@@ -48,8 +49,26 @@ async function create(req, res) {
   })
 }
 
+function destroy(req, res) {
+  let foodId = req.params.id
+
+  Food.findOne({ where: { id: foodId } })
+  .then(singleFood => {
+    singleFood.destroy();
+    res.setHeader("Content-Type", "application/json");
+    res.status(204).send();
+    // no body content delivered with 204 status code
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(404).send({"error": error.message});
+  })
+}
+
+
 module.exports = {
   index: index,
   show: show,
   create: create,
+  destroy: destroy
 }

--- a/migrations/20190704002811-create-mealfood.js
+++ b/migrations/20190704002811-create-mealfood.js
@@ -15,7 +15,8 @@ module.exports = {
           key: 'id',
           // This declares when to check the foreign key constraint. PostgreSQL only.
           deferrable: Sequelize.Deferrable.INITIALLY_IMMEDIATE
-        }
+        },
+        onDelete: 'cascade'
       },
       foodId: {
         type: Sequelize.INTEGER,
@@ -24,8 +25,10 @@ module.exports = {
           key: 'id',
           // This declares when to check the foreign key constraint. PostgreSQL only.
           deferrable: Sequelize.Deferrable.INITIALLY_IMMEDIATE
-        }
-      },      createdAt: {
+        },
+        onDelete: 'cascade'
+      },
+      createdAt: {
         allowNull: false,
         type: Sequelize.DATE
       },

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -17,5 +17,10 @@ router.post('/', function(req, res) {
   foodsController.create(req, res);
 });
 
+// Delete
+router.delete('/:id', function(req, res) {
+  foodsController.destroy(req,res);
+})
+
 
 module.exports = router;


### PR DESCRIPTION
- [ ] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #23

**Description:**
Creates route for DELETE /api/v1/foods/:id
Creates `destroy` function in foods_controller
Changes `show` and `create` actions in foods_controller from async to regular function
Adds `onDelete: 'cascade'` to foreign keys in MealFoods joins table

## What did you struggle on to complete?
I was hung up for a while trying to figure out why I could not return a message in the body when using a `204` status code. 

## Current Test Suite:
### Test Coverage Percentage: NA%
- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain why):
*need to backfill with Jest once we figure that out*

## Helpful Resources:
* Resource link AND small description of info gathered/learned   

[Destroy Join Table Dependents](https://stackoverflow.com/questions/41851839/sequelize-model-delete-item-with-belongstomany-nm-association)
*by adding `onDelete: 'cascade'` to the foreign keys of the MealFoods joins table, when a single food (or meal) is destroyed - so are any of its accompanying records in the joins table.*

[HTTP Status Codes - and descriptions](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
"The 204 response MUST NOT include a message-body, and thus is always terminated by the first empty line after the header fields."

## Review Requests(optional):
@blake-enyart, @Vjp888 - can you take a look and see if you are ok with moving away from async functions in the `foods_controller`? I went this route to try and keep things consistent, and so that we could use the `.catch` method to get more explicit error messages.

## Please include an emoji of how you feel about this branch:
🤔